### PR TITLE
Update Go version to 1.23.5 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bottledcode/atlas-db
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/caddyserver/caddy/v2 v2.9.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Go version from 1.23.4 to 1.23.5
<!-- end of auto-generated comment: release notes by coderabbit.ai -->