### PR TITLE
Odyssean ACL refactor: Protobuf ACLData, grant/revoke, meta:acl keying

### DIFF
--- a/atlas/commands/acl-command.go
+++ b/atlas/commands/acl-command.go
@@ -1,0 +1,164 @@
+/*
+ * This file is part of Atlas-DB.
+ *
+ * Atlas-DB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Atlas-DB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Atlas-DB. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bottledcode/atlas-db/atlas/consensus"
+	"github.com/bottledcode/atlas-db/atlas/kv"
+	"github.com/bottledcode/atlas-db/atlas/options"
+	"go.uber.org/zap"
+)
+
+type ACLCommand struct {
+	CommandString
+}
+
+func (c *ACLCommand) GetNext() (Command, error) {
+	if next, ok := c.SelectNormalizedCommand(1); ok {
+		switch next {
+		case "GRANT":
+			return &ACLGrantCommand{*c}, nil
+		case "REVOKE":
+			return &ACLRevokeCommand{*c}, nil
+		}
+		return EmptyCommandString, fmt.Errorf("ACL command expected GRANT or REVOKE, got %s", next)
+	}
+	return EmptyCommandString, fmt.Errorf("ACL command requires GRANT or REVOKE")
+}
+
+// ACLGrantCommand handles ACL GRANT <principal> <table> <key>
+type ACLGrantCommand struct {
+	ACLCommand
+}
+
+func (c *ACLGrantCommand) GetNext() (Command, error) {
+	return c, nil
+}
+
+func (c *ACLGrantCommand) Execute(ctx context.Context) ([]byte, error) {
+	// ACL GRANT <table> <name> PERMS <permissions>
+	if err := c.CheckMinLen(6); err != nil {
+		return nil, err
+	}
+
+	tableKey, _ := c.SelectNormalizedCommand(2)
+	principal := c.SelectCommand(3)
+	permsKeyword, _ := c.SelectNormalizedCommand(4)
+	permissions := c.SelectCommand(5)
+
+	if tableKey == "" || principal == "" || permsKeyword != "PERMS" || permissions == "" {
+		return nil, fmt.Errorf("ACL GRANT requires format: ACL GRANT <table> <name> PERMS <permissions>")
+	}
+
+	// Get the metadata store
+	kvPool := kv.GetPool()
+	if kvPool == nil {
+		return nil, fmt.Errorf("KV pool not initialized")
+	}
+
+	metaStore := kvPool.MetaStore()
+	if metaStore == nil {
+		return nil, fmt.Errorf("metadata store not available")
+	}
+
+	// Convert dotted key to KeyBuilder format to match what ReadKey uses
+	builder := kv.FromDottedKey(tableKey)
+	builtKey := string(builder.Build())
+
+	// Grant ACL using our consensus helper
+	// TODO: Implement permission parsing (READ|WRITE|OWNER)
+	err := consensus.GrantACLToKey(ctx, metaStore, builtKey, principal)
+	if err != nil {
+		options.Logger.Error("Failed to grant ACL",
+			zap.String("principal", principal),
+			zap.String("tableKey", tableKey),
+			zap.String("permissions", permissions),
+			zap.Error(err))
+		return nil, fmt.Errorf("failed to grant ACL: %w", err)
+	}
+
+	options.Logger.Info("ACL granted successfully",
+		zap.String("principal", principal),
+		zap.String("tableKey", tableKey),
+		zap.String("permissions", permissions))
+
+	return fmt.Appendf(nil, "ACL granted to %s for %s with permissions %s", principal, builtKey, permissions), nil
+}
+
+// ACLRevokeCommand handles ACL REVOKE <principal> <table> <key>
+type ACLRevokeCommand struct {
+	ACLCommand
+}
+
+func (c *ACLRevokeCommand) GetNext() (Command, error) {
+	return c, nil
+}
+
+func (c *ACLRevokeCommand) Execute(ctx context.Context) ([]byte, error) {
+	// ACL REVOKE <table> <name> PERMS <permissions>
+	if err := c.CheckMinLen(6); err != nil {
+		return nil, err
+	}
+
+	tableKey, _ := c.SelectNormalizedCommand(2)
+	principal := c.SelectCommand(3)
+	permsKeyword, _ := c.SelectNormalizedCommand(4)
+	permissions := c.SelectCommand(5)
+
+	if tableKey == "" || principal == "" || permsKeyword != "PERMS" || permissions == "" {
+		return nil, fmt.Errorf("ACL REVOKE requires format: ACL REVOKE <table> <name> PERMS <permissions>")
+	}
+
+	// Get the metadata store
+	kvPool := kv.GetPool()
+	if kvPool == nil {
+		return nil, fmt.Errorf("KV pool not initialized")
+	}
+
+	metaStore := kvPool.MetaStore()
+	if metaStore == nil {
+		return nil, fmt.Errorf("metadata store not available")
+	}
+
+	// Convert dotted key to KeyBuilder format to match what ReadKey uses
+	builder := kv.FromDottedKey(tableKey)
+	builtKey := string(builder.Build())
+
+	// Revoke ACL using our consensus helper
+	// TODO: Implement permission parsing (READ|WRITE|OWNER)
+	err := consensus.RevokeACLFromKey(ctx, metaStore, builtKey, principal)
+	if err != nil {
+		options.Logger.Error("Failed to revoke ACL",
+			zap.String("principal", principal),
+			zap.String("tableKey", tableKey),
+			zap.String("permissions", permissions),
+			zap.Error(err))
+		return nil, fmt.Errorf("failed to revoke ACL: %w", err)
+	}
+
+	options.Logger.Info("ACL revoked successfully",
+		zap.String("principal", principal),
+		zap.String("tableKey", tableKey),
+		zap.String("permissions", permissions))
+
+	return fmt.Appendf(nil, "ACL revoked from %s for %s with permissions %s", principal, builtKey, permissions), nil
+}

--- a/atlas/commands/acl-command_test.go
+++ b/atlas/commands/acl-command_test.go
@@ -1,0 +1,299 @@
+/*
+ * This file is part of Atlas-DB.
+ *
+ * Atlas-DB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Atlas-DB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Atlas-DB. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package commands
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bottledcode/atlas-db/atlas/consensus"
+	"github.com/bottledcode/atlas-db/atlas/kv"
+	"github.com/bottledcode/atlas-db/atlas/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestACLCommand_Parsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		command     string
+		expectError bool
+		expectType  any
+	}{
+		{
+			name:        "ACL GRANT command",
+			command:     "ACL GRANT users.123 alice PERMS READ",
+			expectError: false,
+			expectType:  &ACLGrantCommand{},
+		},
+		{
+			name:        "ACL REVOKE command",
+			command:     "ACL REVOKE users.456 bob PERMS WRITE",
+			expectError: false,
+			expectType:  &ACLRevokeCommand{},
+		},
+		{
+			name:        "ACL with invalid subcommand",
+			command:     "ACL LIST alice users",
+			expectError: true,
+		},
+		{
+			name:        "ACL with no subcommand",
+			command:     "ACL",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := CommandFromString(tt.command)
+			cmd, err := cs.GetNext()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.IsType(t, tt.expectType, cmd)
+		})
+	}
+}
+
+func TestACLGrantCommand_Parse_Args(t *testing.T) {
+	tests := []struct {
+		name        string
+		command     string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "Valid grant command",
+			command:     "ACL GRANT users.123 alice PERMS READ",
+			expectError: false,
+		},
+		{
+			name:        "Missing arguments",
+			command:     "ACL GRANT users.123 alice",
+			expectError: true,
+			errorMsg:    "expects 6 arguments",
+		},
+		{
+			name:        "Missing PERMS keyword",
+			command:     "ACL GRANT users.123 alice READ extra",
+			expectError: true,
+			errorMsg:    "ACL GRANT requires format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := CommandFromString(tt.command)
+			cmd, err := cs.GetNext()
+			require.NoError(t, err)
+
+			grantCmd, ok := cmd.(*ACLGrantCommand)
+			require.True(t, ok)
+
+			// Test parsing by attempting execution (will fail on KV pool, but parsing will work)
+			_, err = grantCmd.Execute(context.Background())
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestACLRevokeCommand_Parse_Args(t *testing.T) {
+	tests := []struct {
+		name        string
+		command     string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "Valid revoke command",
+			command:     "ACL REVOKE users.456 bob PERMS WRITE",
+			expectError: false,
+		},
+		{
+			name:        "Missing arguments",
+			command:     "ACL REVOKE users.456 bob",
+			expectError: true,
+			errorMsg:    "expects 6 arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := CommandFromString(tt.command)
+			cmd, err := cs.GetNext()
+			require.NoError(t, err)
+
+			revokeCmd, ok := cmd.(*ACLRevokeCommand)
+			require.True(t, ok)
+
+			// Test parsing by attempting execution (will fail on KV pool, but parsing will work)
+			_, err = revokeCmd.Execute(context.Background())
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestACLCommands_Integration(t *testing.T) {
+	// Setup test environment
+	cleanup := setupKVForACL(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Test ACL GRANT
+	grantCmd := CommandFromString("ACL GRANT users.123 alice PERMS READ")
+	cmd, err := grantCmd.GetNext()
+	require.NoError(t, err)
+
+	result, err := cmd.Execute(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "ACL granted to alice for USERS.123 with permissions READ")
+
+	// Verify ACL was set by checking the metadata store directly
+	kvPool := kv.GetPool()
+	metaStore := kvPool.MetaStore()
+	aclKey := consensus.CreateACLKey("USERS.123")
+	aclVal, err := metaStore.Get(ctx, []byte(aclKey))
+	require.NoError(t, err)
+
+	aclData, err := consensus.DecodeACLData(aclVal)
+	require.NoError(t, err)
+	assert.True(t, consensus.HasPrincipal(aclData, "alice"))
+
+	// Test ACL GRANT to add another principal
+	grantCmd2 := CommandFromString("ACL GRANT users.123 bob PERMS WRITE")
+	cmd2, err := grantCmd2.GetNext()
+	require.NoError(t, err)
+
+	result2, err := cmd2.Execute(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, string(result2), "ACL granted to bob for USERS.123 with permissions WRITE")
+
+	// Verify both principals have access
+	aclVal2, err := metaStore.Get(ctx, []byte(aclKey))
+	require.NoError(t, err)
+
+	aclData2, err := consensus.DecodeACLData(aclVal2)
+	require.NoError(t, err)
+	assert.True(t, consensus.HasPrincipal(aclData2, "alice"))
+	assert.True(t, consensus.HasPrincipal(aclData2, "bob"))
+	assert.Len(t, aclData2.Principals, 2)
+
+	// Test ACL REVOKE
+	revokeCmd := CommandFromString("ACL REVOKE users.123 alice PERMS READ")
+	cmd3, err := revokeCmd.GetNext()
+	require.NoError(t, err)
+
+	result3, err := cmd3.Execute(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, string(result3), "ACL revoked from alice for USERS.123 with permissions READ")
+
+	// Verify alice was removed but bob remains
+	aclVal3, err := metaStore.Get(ctx, []byte(aclKey))
+	require.NoError(t, err)
+
+	aclData3, err := consensus.DecodeACLData(aclVal3)
+	require.NoError(t, err)
+	assert.False(t, consensus.HasPrincipal(aclData3, "alice"))
+	assert.True(t, consensus.HasPrincipal(aclData3, "bob"))
+	assert.Len(t, aclData3.Principals, 1)
+
+	// Test ACL REVOKE last principal (should remove ACL entirely)
+	revokeCmd2 := CommandFromString("ACL REVOKE users.123 bob PERMS WRITE")
+	cmd4, err := revokeCmd2.GetNext()
+	require.NoError(t, err)
+
+	result4, err := cmd4.Execute(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, string(result4), "ACL revoked from bob for USERS.123 with permissions WRITE")
+
+	// Verify ACL was completely removed
+	_, err = metaStore.Get(ctx, []byte(aclKey))
+	assert.Error(t, err) // Should be kv.ErrKeyNotFound
+}
+
+func TestACLCommands_CaseInsensitive(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{
+			name:    "Lowercase acl grant",
+			command: "acl grant users.123 alice perms read",
+		},
+		{
+			name:    "Mixed case acl revoke",
+			command: "Acl Revoke users.456 Bob Perms Write",
+		},
+		{
+			name:    "Uppercase ACL GRANT",
+			command: "ACL GRANT USERS.789 CHARLIE PERMS OWNER",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := CommandFromString(tt.command)
+			cmd, err := cs.GetNext()
+			require.NoError(t, err)
+
+			// Should parse successfully regardless of case
+			if strings.Contains(strings.ToUpper(tt.command), "GRANT") {
+				assert.IsType(t, &ACLGrantCommand{}, cmd)
+			} else {
+				assert.IsType(t, &ACLRevokeCommand{}, cmd)
+			}
+		})
+	}
+}
+
+// setupKVForACL initializes the KV store for ACL testing
+func setupKVForACL(t *testing.T) func() {
+	// Initialize logger
+	options.Logger = zap.NewNop()
+
+	// Setup KV store (similar to server_acl_test.go pattern)
+	data := t.TempDir()
+	meta := t.TempDir()
+	err := kv.CreatePool(data, meta)
+	require.NoError(t, err)
+
+	return func() {
+		_ = kv.DrainPool()
+	}
+}

--- a/atlas/commands/acl-command_test.go
+++ b/atlas/commands/acl-command_test.go
@@ -182,12 +182,13 @@ func TestACLCommands_Integration(t *testing.T) {
 
 	result, err := cmd.Execute(ctx)
 	require.NoError(t, err)
-	assert.Contains(t, string(result), "ACL granted to alice for USERS.123 with permissions READ")
+	builtKey := string(kv.FromDottedKey("USERS.123").Build())
+	assert.Contains(t, string(result), "ACL granted to alice for "+builtKey+" with permissions READ")
 
 	// Verify ACL was set by checking the metadata store directly
 	kvPool := kv.GetPool()
 	metaStore := kvPool.MetaStore()
-	aclKey := consensus.CreateACLKey("USERS.123")
+	aclKey := consensus.CreateACLKey(builtKey)
 	aclVal, err := metaStore.Get(ctx, []byte(aclKey))
 	require.NoError(t, err)
 
@@ -202,7 +203,7 @@ func TestACLCommands_Integration(t *testing.T) {
 
 	result2, err := cmd2.Execute(ctx)
 	require.NoError(t, err)
-	assert.Contains(t, string(result2), "ACL granted to bob for USERS.123 with permissions WRITE")
+	assert.Contains(t, string(result2), "ACL granted to bob for "+builtKey+" with permissions WRITE")
 
 	// Verify both principals have access
 	aclVal2, err := metaStore.Get(ctx, []byte(aclKey))
@@ -221,7 +222,7 @@ func TestACLCommands_Integration(t *testing.T) {
 
 	result3, err := cmd3.Execute(ctx)
 	require.NoError(t, err)
-	assert.Contains(t, string(result3), "ACL revoked from alice for USERS.123 with permissions READ")
+	assert.Contains(t, string(result3), "ACL revoked from alice for "+builtKey+" with permissions READ")
 
 	// Verify alice was removed but bob remains
 	aclVal3, err := metaStore.Get(ctx, []byte(aclKey))
@@ -240,7 +241,7 @@ func TestACLCommands_Integration(t *testing.T) {
 
 	result4, err := cmd4.Execute(ctx)
 	require.NoError(t, err)
-	assert.Contains(t, string(result4), "ACL revoked from bob for USERS.123 with permissions WRITE")
+	assert.Contains(t, string(result4), "ACL revoked from bob for "+builtKey+" with permissions WRITE")
 
 	// Verify ACL was completely removed
 	_, err = metaStore.Get(ctx, []byte(aclKey))

--- a/atlas/commands/string.go
+++ b/atlas/commands/string.go
@@ -75,6 +75,8 @@ func (c *CommandString) GetNext() (Command, error) {
 			return (&SampleCommand{CommandString: *c}).GetNext()
 		case "QUORUM":
 			return (&QuorumCommand{CommandString: *c}).GetNext()
+		case "ACL":
+			return (&ACLCommand{*c}).GetNext()
 		}
 		return EmptyCommandString, fmt.Errorf("command expected, got %s", next)
 	}

--- a/atlas/consensus/acl.go
+++ b/atlas/consensus/acl.go
@@ -2,47 +2,68 @@ package consensus
 
 import (
 	"context"
-	"encoding/binary"
+	"slices"
+	"time"
 
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // gRPC metadata key for the session principal; must be lowercase.
 const atlasPrincipalKey = "atlas-principal"
 
-// aclKeyForDataKey maps a data key to its ACL metadata key.
-func aclKeyForDataKey(dataKey string) []byte {
-	return []byte("meta:acl:" + dataKey)
+// encodeACLData encodes ACLData protobuf message to bytes.
+func encodeACLData(principals []string) ([]byte, error) {
+	now := timestamppb.New(time.Now())
+	aclData := &ACLData{
+		Principals: principals,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	return proto.Marshal(aclData)
 }
 
-// aclKeyForTable maps a table name to its table-level ACL metadata key.
-func aclKeyForTable(table string) []byte {
-	return []byte("meta:acl:table:" + table)
+// decodeACLData decodes bytes to ACLData protobuf message.
+func decodeACLData(b []byte) (*ACLData, error) {
+	var aclData ACLData
+	err := proto.Unmarshal(b, &aclData)
+	if err != nil {
+		return nil, err
+	}
+	return &aclData, nil
 }
 
-// encodeOwner encodes a single-string owner principal as length-prefixed bytes.
-func encodeOwner(owner string) []byte {
-	n := len(owner)
-	if n > 0xFFFF {
-		n = 0xFFFF
-		owner = owner[:n]
-	}
-	b := make([]byte, 2+n)
-	binary.BigEndian.PutUint16(b[:2], uint16(n))
-	copy(b[2:], []byte(owner))
-	return b
+// hasPrincipal checks if a principal exists in the ACL data.
+func hasPrincipal(aclData *ACLData, principal string) bool {
+	return slices.Contains(aclData.Principals, principal)
 }
 
-// decodeOwner decodes a single-string owner principal from length-prefixed bytes.
-func decodeOwner(b []byte) (string, bool) {
-	if len(b) < 2 {
-		return "", false
+// grantPrincipal adds a principal to the ACL data if not already present.
+func grantPrincipal(aclData *ACLData, principal string) *ACLData {
+	if !hasPrincipal(aclData, principal) {
+		return &ACLData{
+			Principals: append(aclData.Principals, principal),
+			CreatedAt:  aclData.CreatedAt,
+			UpdatedAt:  timestamppb.New(time.Now()),
+		}
 	}
-	l := int(binary.BigEndian.Uint16(b[:2]))
-	if len(b) < 2+l {
-		return "", false
+	return aclData
+}
+
+// revokePrincipal removes a principal from the ACL data.
+func revokePrincipal(aclData *ACLData, principal string) *ACLData {
+	result := make([]string, 0, len(aclData.Principals))
+	for _, p := range aclData.Principals {
+		if p != principal {
+			result = append(result, p)
+		}
 	}
-	return string(b[2 : 2+l]), true
+	return &ACLData{
+		Principals: result,
+		CreatedAt:  aclData.CreatedAt,
+		UpdatedAt:  timestamppb.New(time.Now()),
+	}
 }
 
 // getPrincipalFromContext extracts the principal identifier from outgoing/incoming metadata.
@@ -58,4 +79,89 @@ func getPrincipalFromContext(ctx context.Context) string {
 		}
 	}
 	return ""
+}
+
+// checkACLAccess verifies if a principal has access to a key based on ACL data.
+func checkACLAccess(aclData *ACLData, principal string) bool {
+	if aclData == nil || len(aclData.Principals) == 0 {
+		return true // No ACL means public access
+	}
+	return hasPrincipal(aclData, principal)
+}
+
+// createACLKey creates an ACL metadata key for a given data key and table.
+func createACLKey(table, key string) string {
+	return "meta:acl:" + table + ":" + key
+}
+
+// GrantACLToKey grants access to a principal for a specific key by updating ACL metadata.
+// This is designed to be used via WriteKey operations to ensure consensus.
+func GrantACLToKey(ctx context.Context, metaStore interface {
+	Get(context.Context, []byte) ([]byte, error)
+	Put(context.Context, []byte, []byte) error
+}, table, key, principal string) error {
+	aclKey := createACLKey(table, key)
+	aclVal, err := metaStore.Get(ctx, []byte(aclKey))
+
+	var aclData *ACLData
+	if err == nil {
+		// ACL exists - decode it
+		aclData, err = decodeACLData(aclVal)
+		if err != nil {
+			return err
+		}
+	} else {
+		// ACL doesn't exist - create new one
+		aclData = &ACLData{
+			Principals: []string{},
+			CreatedAt:  timestamppb.New(time.Now()),
+			UpdatedAt:  timestamppb.New(time.Now()),
+		}
+	}
+
+	// Grant access to principal
+	updatedACL := grantPrincipal(aclData, principal)
+	encodedACL, err := proto.Marshal(updatedACL)
+	if err != nil {
+		return err
+	}
+
+	return metaStore.Put(ctx, []byte(aclKey), encodedACL)
+}
+
+// RevokeACLFromKey revokes access from a principal for a specific key by updating ACL metadata.
+// This is designed to be used via WriteKey operations to ensure consensus.
+func RevokeACLFromKey(ctx context.Context, metaStore interface {
+	Get(context.Context, []byte) ([]byte, error)
+	Put(context.Context, []byte, []byte) error
+	Delete(context.Context, []byte) error
+}, table, key, principal string) error {
+	aclKey := createACLKey(table, key)
+	aclVal, err := metaStore.Get(ctx, []byte(aclKey))
+	if err != nil {
+		// ACL doesn't exist - nothing to revoke
+		return nil
+	}
+
+	// Decode existing ACL
+	aclData, err := decodeACLData(aclVal)
+	if err != nil {
+		return err
+	}
+
+	// Revoke access from principal
+	updatedACL := revokePrincipal(aclData, principal)
+
+	// If no principals left, delete the ACL entry entirely
+	if len(updatedACL.Principals) == 0 {
+		return metaStore.Delete(ctx, []byte(aclKey))
+	}
+
+	// Otherwise update the ACL
+	encodedACL, err := proto.Marshal(updatedACL)
+	if err != nil {
+		return err
+	}
+
+	return metaStore.Put(ctx, []byte(aclKey), encodedACL)
 }

--- a/atlas/consensus/acl_test.go
+++ b/atlas/consensus/acl_test.go
@@ -3,47 +3,11 @@ package consensus
 import (
 	"context"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-func TestEncodeDecodeOwner(t *testing.T) {
-	owner := "alice"
-	enc := encodeOwner(owner)
-	dec, ok := decodeOwner(enc)
-	if !ok {
-		t.Fatalf("decodeOwner returned !ok")
-	}
-	if dec != owner {
-		t.Fatalf("expected %q, got %q", owner, dec)
-	}
-}
-
-func TestEncodeDecodeOwnerOversized(t *testing.T) {
-	// Create an owner string larger than uint16 max (65535)
-	oversizedOwner := make([]byte, 70000)
-	for i := range oversizedOwner {
-		oversizedOwner[i] = byte('a' + (i % 26))
-	}
-	owner := string(oversizedOwner)
-
-	enc := encodeOwner(owner)
-	dec, ok := decodeOwner(enc)
-	if !ok {
-		t.Fatalf("decodeOwner returned !ok")
-	}
-
-	// Should be truncated to 65535 bytes
-	expectedTruncated := owner[:0xFFFF]
-	if dec != expectedTruncated {
-		t.Fatalf("expected truncated owner of length %d, got length %d", len(expectedTruncated), len(dec))
-	}
-
-	// Verify the encoded length matches the payload
-	if len(enc) != 2+0xFFFF {
-		t.Fatalf("expected encoded length %d, got %d", 2+0xFFFF, len(enc))
-	}
-}
 
 func TestGetPrincipalFromContext(t *testing.T) {
 	// Incoming metadata
@@ -58,5 +22,119 @@ func TestGetPrincipalFromContext(t *testing.T) {
 	ctx2 := metadata.NewOutgoingContext(context.Background(), mdOut)
 	if p := getPrincipalFromContext(ctx2); p != "dave" {
 		t.Fatalf("expected dave from outgoing ctx, got %q", p)
+	}
+}
+
+func TestEncodeDecodeACLData(t *testing.T) {
+	principals := []string{"alice", "bob", "charlie"}
+	encoded, err := encodeACLData(principals)
+	if err != nil {
+		t.Fatalf("encodeACLData failed: %v", err)
+	}
+
+	decoded, err := decodeACLData(encoded)
+	if err != nil {
+		t.Fatalf("decodeACLData failed: %v", err)
+	}
+
+	if len(decoded.Principals) != len(principals) {
+		t.Fatalf("expected %d principals, got %d", len(principals), len(decoded.Principals))
+	}
+
+	for i, expected := range principals {
+		if decoded.Principals[i] != expected {
+			t.Fatalf("expected principal %q at index %d, got %q", expected, i, decoded.Principals[i])
+		}
+	}
+
+	if decoded.CreatedAt == nil || decoded.UpdatedAt == nil {
+		t.Fatalf("timestamps should not be nil")
+	}
+}
+
+func TestGrantRevokeACLData(t *testing.T) {
+	// Start with empty ACL
+	aclData := &ACLData{
+		Principals: []string{},
+		CreatedAt:  timestamppb.New(time.Now()),
+		UpdatedAt:  timestamppb.New(time.Now()),
+	}
+
+	// Grant access to alice
+	updatedACL := grantPrincipal(aclData, "alice")
+	if !hasPrincipal(updatedACL, "alice") {
+		t.Fatalf("alice should have access after grant")
+	}
+	if len(updatedACL.Principals) != 1 {
+		t.Fatalf("expected 1 principal, got %d", len(updatedACL.Principals))
+	}
+
+	// Grant access to bob
+	updatedACL = grantPrincipal(updatedACL, "bob")
+	if !hasPrincipal(updatedACL, "alice") || !hasPrincipal(updatedACL, "bob") {
+		t.Fatalf("both alice and bob should have access")
+	}
+	if len(updatedACL.Principals) != 2 {
+		t.Fatalf("expected 2 principals, got %d", len(updatedACL.Principals))
+	}
+
+	// Granting same principal should not duplicate
+	updatedACL = grantPrincipal(updatedACL, "alice")
+	if len(updatedACL.Principals) != 2 {
+		t.Fatalf("granting existing principal should not duplicate, got %d principals", len(updatedACL.Principals))
+	}
+
+	// Revoke alice
+	updatedACL = revokePrincipal(updatedACL, "alice")
+	if hasPrincipal(updatedACL, "alice") {
+		t.Fatalf("alice should not have access after revoke")
+	}
+	if !hasPrincipal(updatedACL, "bob") {
+		t.Fatalf("bob should still have access")
+	}
+	if len(updatedACL.Principals) != 1 {
+		t.Fatalf("expected 1 principal after revoke, got %d", len(updatedACL.Principals))
+	}
+
+	// Revoke bob
+	updatedACL = revokePrincipal(updatedACL, "bob")
+	if len(updatedACL.Principals) != 0 {
+		t.Fatalf("expected 0 principals after revoking all, got %d", len(updatedACL.Principals))
+	}
+}
+
+func TestCheckACLAccess(t *testing.T) {
+	// Test nil ACL (public access)
+	if !checkACLAccess(nil, "anyone") {
+		t.Fatalf("nil ACL should allow access")
+	}
+
+	// Test empty ACL (public access)
+	emptyACL := &ACLData{Principals: []string{}}
+	if !checkACLAccess(emptyACL, "anyone") {
+		t.Fatalf("empty ACL should allow access")
+	}
+
+	// Test ACL with principals
+	aclData := &ACLData{Principals: []string{"alice", "bob"}}
+	if !checkACLAccess(aclData, "alice") {
+		t.Fatalf("alice should have access")
+	}
+	if !checkACLAccess(aclData, "bob") {
+		t.Fatalf("bob should have access")
+	}
+	if checkACLAccess(aclData, "charlie") {
+		t.Fatalf("charlie should not have access")
+	}
+	if checkACLAccess(aclData, "") {
+		t.Fatalf("empty principal should not have access when ACL is restricted")
+	}
+}
+
+func TestCreateACLKey(t *testing.T) {
+	key := createACLKey("users", "user:123")
+	expected := "meta:acl:users:user:123"
+	if key != expected {
+		t.Fatalf("expected %q, got %q", expected, key)
 	}
 }

--- a/atlas/consensus/acl_test.go
+++ b/atlas/consensus/acl_test.go
@@ -32,9 +32,9 @@ func TestEncodeDecodeACLData(t *testing.T) {
 		t.Fatalf("encodeACLData failed: %v", err)
 	}
 
-	decoded, err := decodeACLData(encoded)
+	decoded, err := DecodeACLData(encoded)
 	if err != nil {
-		t.Fatalf("decodeACLData failed: %v", err)
+		t.Fatalf("DecodeACLData failed: %v", err)
 	}
 
 	if len(decoded.Principals) != len(principals) {
@@ -62,7 +62,7 @@ func TestGrantRevokeACLData(t *testing.T) {
 
 	// Grant access to alice
 	updatedACL := grantPrincipal(aclData, "alice")
-	if !hasPrincipal(updatedACL, "alice") {
+	if !HasPrincipal(updatedACL, "alice") {
 		t.Fatalf("alice should have access after grant")
 	}
 	if len(updatedACL.Principals) != 1 {
@@ -71,7 +71,7 @@ func TestGrantRevokeACLData(t *testing.T) {
 
 	// Grant access to bob
 	updatedACL = grantPrincipal(updatedACL, "bob")
-	if !hasPrincipal(updatedACL, "alice") || !hasPrincipal(updatedACL, "bob") {
+	if !HasPrincipal(updatedACL, "alice") || !HasPrincipal(updatedACL, "bob") {
 		t.Fatalf("both alice and bob should have access")
 	}
 	if len(updatedACL.Principals) != 2 {
@@ -86,10 +86,10 @@ func TestGrantRevokeACLData(t *testing.T) {
 
 	// Revoke alice
 	updatedACL = revokePrincipal(updatedACL, "alice")
-	if hasPrincipal(updatedACL, "alice") {
+	if HasPrincipal(updatedACL, "alice") {
 		t.Fatalf("alice should not have access after revoke")
 	}
-	if !hasPrincipal(updatedACL, "bob") {
+	if !HasPrincipal(updatedACL, "bob") {
 		t.Fatalf("bob should still have access")
 	}
 	if len(updatedACL.Principals) != 1 {
@@ -132,8 +132,8 @@ func TestCheckACLAccess(t *testing.T) {
 }
 
 func TestCreateACLKey(t *testing.T) {
-	key := createACLKey("users", "user:123")
-	expected := "meta:acl:users:user:123"
+	key := CreateACLKey("USERS.USER:123")
+	expected := "meta:acl:USERS.USER:123"
 	if key != expected {
 		t.Fatalf("expected %q, got %q", expected, key)
 	}

--- a/atlas/consensus/consensus.proto
+++ b/atlas/consensus/consensus.proto
@@ -238,3 +238,10 @@ message WriteKeyResponse {
   bool success = 1; // Whether the write was successful
   string error = 2; // Error message if not successful
 }
+
+// ACL data structure for protobuf encoding
+message ACLData {
+  repeated string principals = 1; // List of principals with access to this key
+  google.protobuf.Timestamp created_at = 2; // When ACL was created
+  google.protobuf.Timestamp updated_at = 3; // When ACL was last modified
+}

--- a/atlas/consensus/server.go
+++ b/atlas/consensus/server.go
@@ -306,55 +306,48 @@ func (s *Server) AcceptMigration(ctx context.Context, req *WriteMigrationRequest
 			if ch := d.GetChange(); ch != nil {
 				switch op := ch.GetOperation().(type) {
 				case *KVChange_Set:
-					// If ACL exists for this key, require matching principal
+					// Check per-key ACL; missing ACL allows write (public)
 					if metaStore != nil {
-						b, e := metaStore.Get(ctx, aclKeyForDataKey(string(op.Set.Key)))
-						if e == nil {
-							if owner, ok := decodeOwner(b); ok {
-								if principal == "" || principal != owner {
+						aclKey := createACLKey(tableName, string(op.Set.Key))
+						aclVal, err := metaStore.Get(ctx, []byte(aclKey))
+						if err == nil {
+							// ACL exists - check if principal has access
+							aclData, err := decodeACLData(aclVal)
+							if err != nil {
+								return nil, status.Errorf(codes.Internal, "ACL decode failed")
+							} else {
+								// Use new multi-principal ACL format
+								if !checkACLAccess(aclData, principal) {
 									return nil, status.Errorf(codes.PermissionDenied, "write access denied")
 								}
 							}
-						} else if errors.Is(e, kv.ErrKeyNotFound) {
-							// Fallback to table-level ACL
-							if tb, te := metaStore.Get(ctx, aclKeyForTable(tableName)); te == nil {
-								if owner, ok := decodeOwner(tb); ok {
-									if principal == "" || principal != owner {
-										return nil, status.Errorf(codes.PermissionDenied, "write access denied")
-									}
-								}
-							} else if !errors.Is(te, kv.ErrKeyNotFound) {
-								return nil, status.Errorf(codes.Internal, "ACL check failed: %v", te)
-							}
-						} else {
+						} else if !errors.Is(err, kv.ErrKeyNotFound) {
 							// Unexpected error during ACL check - fail securely
-							return nil, status.Errorf(codes.Internal, "ACL check failed: %v", e)
+							return nil, status.Errorf(codes.Internal, "ACL check failed: %v", err)
 						}
+						// If ACL not found (kv.ErrKeyNotFound), allow write
 					}
 				case *KVChange_Del:
+					// Check per-key ACL; missing ACL allows delete (public)
 					if metaStore != nil {
-						b, e := metaStore.Get(ctx, aclKeyForDataKey(string(op.Del.Key)))
-						if e == nil {
-							if owner, ok := decodeOwner(b); ok {
-								if principal == "" || principal != owner {
+						aclKey := createACLKey(tableName, string(op.Del.Key))
+						aclVal, err := metaStore.Get(ctx, []byte(aclKey))
+						if err == nil {
+							// ACL exists - check if principal has access
+							aclData, err := decodeACLData(aclVal)
+							if err != nil {
+								return nil, status.Errorf(codes.Internal, "ACL decode failed")
+							} else {
+								// Use new multi-principal ACL format
+								if !checkACLAccess(aclData, principal) {
 									return nil, status.Errorf(codes.PermissionDenied, "delete access denied")
 								}
 							}
-						} else if errors.Is(e, kv.ErrKeyNotFound) {
-							// Fallback to table-level ACL
-							if tb, te := metaStore.Get(ctx, aclKeyForTable(tableName)); te == nil {
-								if owner, ok := decodeOwner(tb); ok {
-									if principal == "" || principal != owner {
-										return nil, status.Errorf(codes.PermissionDenied, "delete access denied")
-									}
-								}
-							} else if !errors.Is(te, kv.ErrKeyNotFound) {
-								return nil, status.Errorf(codes.Internal, "ACL check failed: %v", te)
-							}
-						} else {
+						} else if !errors.Is(err, kv.ErrKeyNotFound) {
 							// Unexpected error during ACL check - fail securely
-							return nil, status.Errorf(codes.Internal, "ACL check failed: %v", e)
+							return nil, status.Errorf(codes.Internal, "ACL check failed: %v", err)
 						}
+						// If ACL not found (kv.ErrKeyNotFound), allow delete
 					}
 				}
 			}
@@ -373,11 +366,18 @@ func (s *Server) AcceptMigration(ctx context.Context, req *WriteMigrationRequest
 				switch op := ch.GetOperation().(type) {
 				case *KVChange_Set:
 					if metaStore != nil && principal != "" {
-						// Only set owner if not present (creation)
-						_, e := metaStore.Get(ctx, aclKeyForDataKey(string(op.Set.Key)))
+						// Only set ACL if not present (creation) - use new multi-principal format
+						aclKey := createACLKey(tableName, string(op.Set.Key))
+						_, e := metaStore.Get(ctx, []byte(aclKey))
 						if errors.Is(e, kv.ErrKeyNotFound) {
-							// Key not found - this is the expected case for setting initial ACL
-							if err := metaStore.Put(ctx, aclKeyForDataKey(string(op.Set.Key)), encodeOwner(principal)); err != nil {
+							// ACL not found - create initial ACL for this principal
+							aclData, err := encodeACLData([]string{principal})
+							if err != nil {
+								options.Logger.Warn("Failed to encode ACL data after successful write",
+									zap.String("key", string(op.Set.Key)),
+									zap.String("principal", principal),
+									zap.Error(err))
+							} else if err := metaStore.Put(ctx, []byte(aclKey), aclData); err != nil {
 								// Log error but don't fail the migration since data was already applied
 								options.Logger.Warn("Failed to set ACL after successful write",
 									zap.String("key", string(op.Set.Key)),
@@ -393,7 +393,9 @@ func (s *Server) AcceptMigration(ctx context.Context, req *WriteMigrationRequest
 					}
 				case *KVChange_Del:
 					if metaStore != nil {
-						if err := metaStore.Delete(ctx, aclKeyForDataKey(string(op.Del.Key))); err != nil {
+						// Delete ACL entry using new key format
+						aclKey := createACLKey(tableName, string(op.Del.Key))
+						if err := metaStore.Delete(ctx, []byte(aclKey)); err != nil {
 							// Log error but don't fail the migration since data was already deleted
 							options.Logger.Warn("Failed to delete ACL after successful delete",
 								zap.String("key", string(op.Del.Key)),
@@ -990,33 +992,27 @@ func (s *Server) ReadKey(ctx context.Context, req *ReadKeyRequest) (*ReadKeyResp
 	}
 
 	keyBytes := []byte(req.GetKey())
-	// Check ACL in meta store; missing => public read allowed
+	// Check per-key ACL; missing ACL means public read allowed
 	if metaStore != nil {
 		principal := getPrincipalFromContext(ctx)
-		// First, check row-level ACL
-		aclVal, err := metaStore.Get(ctx, aclKeyForDataKey(req.GetKey()))
+		aclKey := createACLKey(req.GetTable(), req.GetKey())
+		aclVal, err := metaStore.Get(ctx, []byte(aclKey))
 		if err == nil {
-			if owner, ok := decodeOwner(aclVal); ok {
-				if principal == "" || principal != owner {
+			// ACL exists - check if principal has access
+			aclData, err := decodeACLData(aclVal)
+			if err != nil {
+				return &ReadKeyResponse{Success: false, Error: "ACL decode failed"}, nil
+			} else {
+				// Use new multi-principal ACL format
+				if !checkACLAccess(aclData, principal) {
 					return &ReadKeyResponse{Success: false, Error: "access denied"}, nil
 				}
 			}
-		} else if errors.Is(err, kv.ErrKeyNotFound) {
-			// Fallback to table-level ACL if row-level missing
-			if tAcl, tErr := metaStore.Get(ctx, aclKeyForTable(req.GetTable())); tErr == nil {
-				if owner, ok := decodeOwner(tAcl); ok {
-					if principal == "" || principal != owner {
-						return &ReadKeyResponse{Success: false, Error: "access denied"}, nil
-					}
-				}
-			} else if !errors.Is(tErr, kv.ErrKeyNotFound) {
-				// Unexpected error during table-level ACL check - fail securely
-				return &ReadKeyResponse{Success: false, Error: "ACL check failed"}, nil
-			}
-		} else {
+		} else if !errors.Is(err, kv.ErrKeyNotFound) {
 			// Unexpected error during ACL check - fail securely
 			return &ReadKeyResponse{Success: false, Error: "ACL check failed"}, nil
 		}
+		// If ACL not found (kv.ErrKeyNotFound), allow public access
 	}
 
 	// Read the key from local store

--- a/atlas/consensus/server_acl_test.go
+++ b/atlas/consensus/server_acl_test.go
@@ -96,7 +96,7 @@ func TestReadKey_ACL_PublicAndOwner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("encode ACL data: %v", err)
 	}
-	aclKey := createACLKey(table, key)
+	aclKey := CreateACLKey(key)
 	if err := pool.MetaStore().Put(context.Background(), []byte(aclKey), aclData); err != nil {
 		t.Fatalf("set ACL: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestAcceptMigration_WriteDelete_ACL(t *testing.T) {
 	if _, err := s.AcceptMigration(context.Background(), &WriteMigrationRequest{Migration: mig1}); err != nil {
 		t.Fatalf("AcceptMigration public set failed: %v", err)
 	}
-	aclKey := createACLKey(table, key)
+	aclKey := CreateACLKey(key)
 	if _, err := pool.MetaStore().Get(context.Background(), []byte(aclKey)); err == nil {
 		t.Fatalf("unexpected ACL set for public write")
 	}
@@ -148,9 +148,9 @@ func TestAcceptMigration_WriteDelete_ACL(t *testing.T) {
 	}
 	if b, err := pool.MetaStore().Get(context.Background(), []byte(aclKey)); err != nil {
 		t.Fatalf("expected ACL present: %v", err)
-	} else if aclData, err := decodeACLData(b); err != nil {
+	} else if aclData, err := DecodeACLData(b); err != nil {
 		t.Fatalf("failed to decode ACL data: %v", err)
-	} else if !hasPrincipal(aclData, "alice") {
+	} else if !HasPrincipal(aclData, "alice") {
 		t.Fatalf("expected alice to have access, principals: %v", aclData.Principals)
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-key ACLs supporting multiple principals stored via a structured protobuf-backed ACL.
  - CLI commands to GRANT and REVOKE principals on keys.

- **Behavior Changes**
  - Access now enforced by per-key ACLs; missing or empty ACLs grant public access.
  - Improved, clearer ACL-related error messages.

- **Migration**
  - Initial ACLs are created only when missing; existing per-key ACLs are preserved.

- **Tests**
  - Expanded coverage for ACL encoding/decoding, grant/revoke workflows, command parsing, and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->